### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/codeforsanjose/open311-plan-for-san-jose.png?label=ready&title=Ready)](https://waffle.io/codeforsanjose/open311-plan-for-san-jose)
 # open311-plan-for-san-jose
 An App and Infrastructure to report issues within San Jose
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/codeforsanjose/open311-plan-for-san-jose

This was requested by a real person (user 3vivekb) on waffle.io, we're not trying to spam you.
